### PR TITLE
added standard name test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # CORDEX-CMIP6 data request
 
 [![CI](https://github.com/WCRP-CORDEX/data-request-table/actions/workflows/ci.yaml/badge.svg)](https://github.com/WCRP-CORDEX/data-request-table/actions/workflows/ci.yaml)
+[![cmor tables update](https://github.com/WCRP-CORDEX/data-request-table/actions/workflows/update-cmor-tables.yaml/badge.svg)](https://github.com/WCRP-CORDEX/data-request-table/actions/workflows/update-cmor-tables.yaml)
 
 This repository contains a CORDEX-CMIP6 cmor table in csv format (`cmor-table/datasets.csv`) that is used to create [CORDEX-CMIP6 cmor tables](https://github.com/WCRP-CORDEX/cordex-cmip6-cmor-tables). Note, that this table is represented in a [tidy format](https://book.the-turing-way.org/reproducible-research/rdm/rdm-spreadsheets.html#tidy-format-for-spreadsheets) which means that *each row represents one requested dataset*. This table contains all meta data required to be used with the [cmor](https://cmor.llnl.gov/) library to produce [CORDEX-CMIP6 compliant]( https://doi.org/10.5281/zenodo.10961069) datasets.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CORDEX-CMIP6 data request
 
+[![CI](https://github.com/WCRP-CORDEX/data-request-table/actions/workflows/ci.yaml/badge.svg)](https://github.com/WCRP-CORDEX/data-request-table/actions/workflows/ci.yaml)
+
 This repository contains a CORDEX-CMIP6 cmor table in csv format (`cmor-table/datasets.csv`) that is used to create [CORDEX-CMIP6 cmor tables](https://github.com/WCRP-CORDEX/cordex-cmip6-cmor-tables). Note, that this table is represented in a [tidy format](https://book.the-turing-way.org/reproducible-research/rdm/rdm-spreadsheets.html#tidy-format-for-spreadsheets) which means that *each row represents one requested dataset*. This table contains all meta data required to be used with the [cmor](https://cmor.llnl.gov/) library to produce [CORDEX-CMIP6 compliant]( https://doi.org/10.5281/zenodo.10961069) datasets.
 
 The cmor tables, however, are independent from a (domain) specific *data request* which can be only a subset of all datasets in the cmor tables and are supposed to provide some meta data on priorities. These tables are also available in more human-readable xlsx format in the `data-request` subfolder.

--- a/ci/environment.yaml
+++ b/ci/environment.yaml
@@ -7,6 +7,7 @@ dependencies:
   - openpyxl
   - xlsxwriter
   - cf-units
+  - cf_xarray
 # for testing
   - pytest
   - pytest-cov

--- a/ci/environment.yaml
+++ b/ci/environment.yaml
@@ -8,6 +8,7 @@ dependencies:
   - xlsxwriter
   - cf-units
   - cf_xarray
+  - pooch
 # for testing
   - pytest
   - pytest-cov


### PR DESCRIPTION
This pull request includes updates to the `ci/tests.py` file to enhance CF (Climate and Forecast) compliance testing. The most important changes include the addition of a new utility import and a new test function to verify standard names against the CF standard name table.

Enhancements to CF compliance testing:

* [`ci/tests.py`](diffhunk://#diff-52f586b6a0daaa11e1e55a83eb2a120aeaf65b062d29bca149f3d4a469b23829R4): Added import statement for `parse_cf_standard_name_table` from `cf_xarray.utils`.
* [`ci/tests.py`](diffhunk://#diff-52f586b6a0daaa11e1e55a83eb2a120aeaf65b062d29bca149f3d4a469b23829R129-R152): Added `test_all_standard_names_cf_conform` function to ensure that all 'standard_name' attributes in the CMOR tables match the CF standard name table, flagging any non-conforming or missing standard names as errors.