### PR TITLE
update tests for standard names and aliases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         # python versions
-        python-version: ["3.10"]
+        python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/update-cmor-tables.yaml
+++ b/.github/workflows/update-cmor-tables.yaml
@@ -29,7 +29,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Install dependencies
       run: |

--- a/ci/environment.yaml
+++ b/ci/environment.yaml
@@ -9,6 +9,7 @@ dependencies:
   - cf-units
   - cf_xarray
   - pooch
+  - pyyaml
 # for testing
   - pytest
   - pytest-cov

--- a/ci/tests.py
+++ b/ci/tests.py
@@ -136,12 +136,10 @@ def test_all_standard_names_cf_conform():
     or missing standard names are flagged as errors.
     """
     # source = "https://raw.githubusercontent.com/cf-convention/cf-convention.github.io/master/Data/cf-standard-names/current/src/cf-standard-name-table.xml"
-    cf_table = parse_cf_standard_name_table()
-    standard_names = list(cf_table[1].keys()) + [
-        "heat_flux_correction"
-    ]  # heat_flux_correction is an alias for "heat_flux_into_sea_water_due_to_flux_adjustment"
+    info, table, aliases = parse_cf_standard_name_table()
+    valid = list(table.keys()) + list(aliases.keys())
     df = pd.read_csv(cmor_tables)
-    non_cf_standard_names = df.loc[~df.standard_name.isin(standard_names)][
+    non_cf_standard_names = df.loc[~df.standard_name.isin(valid)][
         ["out_name", "standard_name", "realm"]
     ].drop_duplicates()
 

--- a/ci/tests.py
+++ b/ci/tests.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from cf_xarray.utils import parse_cf_standard_name_table
-from .utils import cmor_tables, tables
+from .utils import cmor_tables, tables, parse_area_type, parse_cell_methods
 
 
 @pytest.mark.parametrize("dreq_file", tables)
@@ -130,6 +130,8 @@ def test_all_units_cf_conform():
 
 def test_all_standard_names_cf_conform():
     """
+    Ensure all standard names are CF conform in the CMOR tables.
+
     This test verifies that the 'standard_name' attribute for all entries in the CMOR tables
     matches the CF standard name table. It parses the CF standard name table and compares
     it against the 'standard_name' column in the CMOR tables. Any entries with non-conforming
@@ -148,3 +150,39 @@ def test_all_standard_names_cf_conform():
             f"Non CF conform standard names: {non_cf_standard_names.standard_name.to_list()}"
         )
     assert non_cf_standard_names.empty
+
+
+def test_all_area_types_cf_conform():
+    """
+    Ensure all area types are CF conform in the CMOR tables.
+
+    This test verifies that the 'area_type' attribute for all entries in the CMOR tables
+    matches the CF area type table. It parses the CF area type table and compares it
+    against the 'area_type' column in the CMOR tables. Any entries with non-conforming
+    or missing area types are flagged as errors.
+    """
+    import pooch
+
+    downloader = pooch.HTTPDownloader(
+        # https://github.com/readthedocs/readthedocs.org/issues/11763
+        headers={"User-Agent": "data-request-validator"},
+    )
+
+    source = pooch.retrieve(
+        "https://raw.githubusercontent.com/cf-convention/cf-convention.github.io/main/Data/area-type-table/current/src/area-type-table.xml",
+        known_hash=None,
+        downloader=downloader,
+    )
+
+    info, table, aliases = parse_cf_standard_name_table(source)
+    valid = list(table.keys()) + list(aliases.keys())
+
+    df = pd.read_csv(cmor_tables)
+
+    df["area_type"] = df.cell_methods.apply(
+        lambda x: parse_cell_methods(x).get("area")
+    ).apply(parse_area_type)
+
+    non_cf_area_types = df[(df.area_type.notnull()) & ~df.area_type.isin(valid)]
+
+    assert non_cf_area_types.empty

--- a/ci/utils.py
+++ b/ci/utils.py
@@ -1,6 +1,8 @@
 import pandas as pd
 from os import path as op
 import glob
+import re
+import yaml
 
 cmor_tables = "cmor-table/datasets.csv"
 table_dir = "data-request"
@@ -8,6 +10,27 @@ table_dir = "data-request"
 cols = ["out_name", "standard_name", "long_name", "units", "cell_methods"]
 
 tables = glob.glob(op.join(table_dir, "*.csv"))
+
+
+def parse_cell_methods(cm_string):
+    # https://stackoverflow.com/questions/52340963/how-to-insert-a-newline-character-before-a-words-that-contains-a-colon
+    ys = re.sub(r"(\w+):", r"\n\1:", cm_string).strip()
+    d = yaml.safe_load(ys)
+
+    if "area" in d and d.get("area") is None:
+        d["area"] = d["time"]
+
+    return d
+
+
+def parse_area_type(area=None):
+    if area is None:
+        return None
+    split = area.split(" ")
+    if len(split) == 3 and split[1] == "where":
+        return split[2]
+    else:
+        return None
 
 
 def human_readable(df):


### PR DESCRIPTION
This pull request includes a change to the `ci/tests.py` file to enhance the validation process for CF standard names by updating the `test_all_standard_names_cf_conform` function.

Improvements to CF standard names validation:

* [`ci/tests.py`](diffhunk://#diff-52f586b6a0daaa11e1e55a83eb2a120aeaf65b062d29bca149f3d4a469b23829L139-R142): Modified the `parse_cf_standard_name_table` function to return `info`, `table`, and `aliases`. Updated the `standard_names` list to include both `table` and `aliases` keys for validation.